### PR TITLE
blescan must be initialized before calling startPortal when known_wifis.txt does not exist

### DIFF
--- a/esp32_ruuvicollector.ino
+++ b/esp32_ruuvicollector.ino
@@ -312,7 +312,10 @@ void setup() {
 
     Serial.begin(115200);
     Serial.println("\n\nESP32 Ruuvi Collector by OH2MP 2020");
-    
+
+    BLEDevice::init("");
+    blescan = BLEDevice::getScan();
+
     SPIFFS.begin();
 
     loadSavedTags();
@@ -368,12 +371,12 @@ void setup() {
         sprintf(url,"%s://%s:%d%s\0",scheme,host,port,path);
     }
 
-    BLEDevice::init("");
-    blescan = BLEDevice::getScan();
-    blescan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
-    blescan->setActiveScan(true);
-    blescan->setInterval(100);
-    blescan->setWindow(99);
+    if (portal_timer == 0) { // are we not in portal mode?
+        blescan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
+        blescan->setActiveScan(true);
+        blescan->setInterval(100);
+        blescan->setWindow(99);
+    }
 }
 
 /* ------------------------------------------------------------------------------- */


### PR DESCRIPTION
If known_wifis.txt does not exist setup() will execute startPortal() at line 356. However, global variable blescan won't be initialized until at lines 371-372 and startPortal() tries to reference the variable at line 443. This will cause the device to get into boot loop.